### PR TITLE
Fix hash map exception part 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>saro476.globaleffects</groupId>
     <artifactId>globaleffects</artifactId>
-    <version>1.0.1-beta</version>
+    <version>1.0.2-beta</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>saro476.globaleffects</groupId>
     <artifactId>globaleffects</artifactId>
-    <version>1.0.0-beta</version>
+    <version>1.0.1-beta</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/com/saro476/globaleffects/GlobalEffects.java
+++ b/src/main/java/com/saro476/globaleffects/GlobalEffects.java
@@ -14,16 +14,16 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 
-import java.util.HashMap;
 import java.util.Set;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 
 
 public class GlobalEffects extends JavaPlugin implements Listener {
 
     // private PotionEffect[] effects = new PotionEffect[2];
     private FileConfiguration config = null;
-    private HashMap<PotionEffectType,PotionEffect> effects = new HashMap<PotionEffectType,PotionEffect>();
+    private ConcurrentHashMap<PotionEffectType,PotionEffect> effects = new ConcurrentHashMap<PotionEffectType,PotionEffect>();
 
     private boolean debug = false;
 
@@ -63,7 +63,7 @@ public class GlobalEffects extends JavaPlugin implements Listener {
         
         debugLogger(event.getPlayer().getName() + " joined the world, delaying effects " + this.config.getInt("join-delay") + " ticks" );
 
-        HashMap<PotionEffectType,PotionEffect> effects = this.effects;
+        ConcurrentHashMap<PotionEffectType,PotionEffect> effects = this.effects;
 
         new BukkitRunnable() {
             @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,6 +16,11 @@ duration: 600
 # Delay is in ticks
 join-delay: 400
 
+# Delay after a player respawns after death before applying effects
+# Increase this number if some players take a long time to respawn
+# Delay is in ticks
+respawn-delay: 100
+
 # Effects to add to all players in the allowed worlds
 # Effects stack on top of other effects like potions and beacons
 # Set to 0 to disable

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: GlobalEffects
-version: '1.0.0'
+version: '1.0.1'
 main: com.saro476.globaleffects.GlobalEffects
 api-version: '1.19'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: GlobalEffects
-version: '1.0.1'
+version: '1.0.2'
 main: com.saro476.globaleffects.GlobalEffects
 api-version: '1.19'


### PR DESCRIPTION
The exception actually occurs in the respawn event. This change will apply global effects after the respawn event completes